### PR TITLE
Add parameter to control whether or not to force a GC before harness

### DIFF
--- a/configs/common.yml
+++ b/configs/common.yml
@@ -68,9 +68,15 @@ modifiers:
   harness_lib:
     type: JSArg
     val: --harness_lib=/home/wenyuz/v8-mapword/evaluation/harness/libharness.so
+  gc_before_harness:
+    type: ProgramArg
+    val: "true"
+  expose_gc:
+    type: JSArg
+    val: --expose-gc-as=v8GC
   harness:
     type: ModifierSet
-    val: enable_harness|harness_lib
+    val: enable_harness|harness_lib|expose_gc|gc_before_harness
   mn:
     type: JSArg
     val: --max_semi_space_size={0}

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -14,12 +14,13 @@ test: libharness.so harness_test
 	./harness_test
 
 test-v8: D8=../v8/out/x64.release-harness/d8
-test-v8: D8_ARGS=--initial-heap-size=21 --max-heap-size=21 --no-lazy --predictable --predictable-gc-schedule
+test-v8: D8_ARGS=--initial-heap-size=21 --max-heap-size=21 --no-lazy --predictable --predictable-gc-schedule --expose-gc-as=v8GC
 test-v8: HARNESS_ARGS=--harness --harness_lib=/home/wenyuz/v8/running/harness/libharness.so
+test-v8: GC_BEFORE_HARNESS=true # If true, requires --expose-gc-as=v8GC in D7_ARGS
 test-v8: libharness.so
 	cd ../../v8 && ./tools/dev/gm.py x64.release-harness
-	cd .. && ../v8/out/x64.release-harness/d8 $(D8_ARGS) ./bin/octane.js -- ../octane box2d 5
-	cd .. && ../v8/out/x64.release-harness/d8 $(D8_ARGS) $(HARNESS_ARGS) ./bin/octane.js -- ../octane box2d 5
+	cd .. && ../v8/out/x64.release-harness/d8 $(D8_ARGS) ./bin/octane.js -- ../octane box2d 5 $(GC_BEFORE_HARNESS)
+	cd .. && ../v8/out/x64.release-harness/d8 $(D8_ARGS) $(HARNESS_ARGS) ./bin/octane.js -- ../octane box2d 5 $(GC_BEFORE_HARNESS)
 
 clean:
 	rm -f *.o *.so *_test

--- a/harness/octane.js
+++ b/harness/octane.js
@@ -1,13 +1,14 @@
 // cd v8/running/
-// ../v8/out/x64.release/d8 --initial-heap-size=142 --max-heap-size=142 --no-lazy --predictable --predictable-gc-schedule ./bin/octane.js -- ../octane box2d 3
+// ../v8/out/x64.release/d8 --initial-heap-size=142 --max-heap-size=142 --no-lazy --predictable --predictable-gc-schedule ./bin/octane.js -- ../octane box2d 3 true
 //
-// ./v8/out/x64.release-header-markbit/d8 --harness --harness_lib=./evaluation/harness/harness.so --initial-heap-size=142 --max-heap-size=142 --no-lazy --predictable --predictable-gc-schedule ./evaluation/harness/octane.js -- ./octane box2d 30
+// ./v8/out/x64.release-header-markbit/d8 --harness --harness_lib=./evaluation/harness/harness.so --initial-heap-size=142 --max-heap-size=142 --no-lazy --predictable --predictable-gc-schedule ./evaluation/harness/octane.js -- ./octane box2d 30 true
 
 if (globalThis.harnessPrepare) harnessPrepare();
 
 const octane_dir = arguments[0];
 const benchmark_name = arguments[1];
 const iterations = arguments[2] || 1;
+const gc_before_harness = arguments[3] == "true";
 
 const base_dir = octane_dir + '/';
 
@@ -54,7 +55,13 @@ function RunOneIteration(iter, isWarmup) {
   if (isWarmup) print(`===== DaCapo ${benchmark_name} starting warmup =====`);
   else print(`===== DaCapo ${benchmark_name} starting =====`);
 
-  if (!isWarmup && globalThis.harnessBegin) harnessBegin();
+  if (!isWarmup && globalThis.harnessBegin) {
+    if (gc_before_harness) {
+        v8GC();
+        print(`GC before harness completed ...`);
+    }
+    harnessBegin();
+  }
   const startTime = new Date();
   // for (let i = 0; i < 10; i++) {
   const { time, score, latencyScore } = BenchmarkSuite.RunOnce();


### PR DESCRIPTION
Forcing a GC before measurements are taken is useful for improving fairness when comparing different GCs. This PR adds a program parameter to octane.js to allow users to control whether to invoke a GC before harnessBegin() or not.