### PR TITLE
Use MMTK statistics naming convention

### DIFF
--- a/harness-20230828.patch
+++ b/harness-20230828.patch
@@ -54,7 +54,7 @@ index 8c3997f24b8..eb4b04aebd3 100644
 +  if (!i::v8_flags.harness) return;
 +  auto isolate = reinterpret_cast<internal::Isolate*>(args.GetIsolate());
 +  auto heap = isolate->heap();
-+  harness.HarnessBegin("GC", static_cast<double>(heap->gc_count()), "time.gc",
++  harness.HarnessBegin("GC", static_cast<double>(heap->gc_count()), "time.stw",
 +                       static_cast<double>(heap->total_gc_time_ms()));
 +}
 +
@@ -62,7 +62,7 @@ index 8c3997f24b8..eb4b04aebd3 100644
 +  if (!i::v8_flags.harness) return;
 +  auto isolate = reinterpret_cast<internal::Isolate*>(args.GetIsolate());
 +  auto heap = isolate->heap();
-+  harness.HarnessEnd("GC", static_cast<double>(heap->gc_count()), "time.gc",
++  harness.HarnessEnd("GC", static_cast<double>(heap->gc_count()), "time.stw",
 +                     static_cast<double>(heap->total_gc_time_ms()));
 +}
 +

--- a/harness/harness.cpp
+++ b/harness/harness.cpp
@@ -66,8 +66,8 @@ private:
     }
 
     void Print() {
-        if (results_.find("time") != results_.end() && results_.find("time.gc") != results_.end()) {
-            results_["time.mu"] = results_["time"] - results_["time.gc"];
+        if (results_.find("time") != results_.end() && results_.find("time.stw") != results_.end()) {
+            results_["time.other"] = results_["time"] - results_["time.stw"];
         }
         cout << "============================ MMTk Statistics Totals ============================" << endl;
         for (auto& x : results_) cout << x.first << TAB;


### PR DESCRIPTION
The new naming convention for MMTK statistics is time.stw, time.other, and time. The PR makes the requires changes to follow that.