### PR TITLE
Adding simpler harness implementation for Android environments

### DIFF
--- a/harness-android/README.md
+++ b/harness-android/README.md
@@ -1,0 +1,15 @@
+### How to build the harness program for Android on a linux machine
+
+1. Download the latest linux package of the Android NDK tool from https://developer.android.com/ndk
+1. Unpack the package and export its location to NDK_HOME
+1. Run this command to generate the .so library:
+
+    ```
+    $NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ \
+    --target=aarch64-linux-android33 -shared -fPIC \
+    -ffunction-sections -fdata-sections -Wl,--gc-sections \
+    -O2 -static-libstdc++ harness.cpp -o libharness.so
+    ```
+
+    The above assumes you are using Android API version 33. 
+    Modify the command as needed to match your requirements.

--- a/harness-android/assert.hpp
+++ b/harness-android/assert.hpp
@@ -1,0 +1,12 @@
+#ifndef ASSERT_HPP
+#define ASSERT_HPP
+
+#include <err.h>
+#include <errno.h>
+
+#define ASSERT(condition, ...)   \
+    if (!(condition)) {          \
+        errx(1, __VA_ARGS__);    \
+        exit(-1);                \
+    }
+#endif

--- a/harness-android/harness.cpp
+++ b/harness-android/harness.cpp
@@ -1,0 +1,189 @@
+#include <iostream>
+#include <map>
+#include <chrono>
+#include <cmath>
+#include <cstdarg>
+#include <iomanip>
+#include <sstream>
+#include <array>
+#include <vector>
+#include "perf_event.hpp"
+
+#define TAB '	'
+
+using namespace std;
+using namespace std::string_literals;
+
+namespace std {
+    string to_string(string s) {
+        return s;
+    }
+}
+
+class Harness {
+public:
+
+    void HarnessPrepare(bool includePerfCounters) {
+        includePerf = includePerfCounters;
+        results_.clear();
+    }
+
+    void HarnessBegin(map<string, double> statistics) {
+        begin_vm_statistics_ = statistics;
+        if (includePerf) {
+            perf_events_.Enable();
+            begin_perf_results_ = perf_events_.ReadAll();
+        }
+        begin_time_ = chrono::steady_clock::now();
+    }
+
+    void HarnessEnd(map<string, double> statistics) {
+        auto end_time = chrono::steady_clock::now();
+        array<uint64_t, N> end_perf_results;
+        if (includePerf) {
+            end_perf_results = perf_events_.ReadAll();
+        }
+        for (auto& p : statistics) {
+            SetResult(p.first, p.second - begin_vm_statistics_[p.first]);
+        }
+        SetResult("time", chrono::duration_cast<chrono::milliseconds>(end_time - begin_time_).count());
+        if (includePerf) {
+            for (size_t i = 0; i < perf_events_.num_events; i++) {
+                SetResult(perf_events_.names[i], end_perf_results[i] - begin_perf_results_[i]);
+            }
+            perf_events_.Disable();
+        }
+        CalculateResults();
+       //Print();
+    }
+
+    void STWBegin() {
+        if (includePerf) {
+            stw_begin_perf_results_ = perf_events_.ReadAll();
+        }
+    }
+    void STWEnd() {
+        if (includePerf) {
+            auto stw_end_perf_results_ = perf_events_.ReadAll();
+            for (size_t i = 0; i < perf_events_.num_events; i++) {
+                AddResult(perf_events_.names[i]+".stw", stw_end_perf_results_[i] - stw_begin_perf_results_[i]);
+            }
+        }
+    }
+
+    char** GetResultKeys() {
+        return keys_ptr;
+    }
+
+    double* GetResultValues() {
+        return values_ptr;
+    }
+
+    int GetResultResult() {
+        return ptr_size;
+    }
+
+    char* GetResultAsString() {
+        return (char*)result_as_string.c_str();
+    }
+    
+private:
+    static constexpr size_t N = 2;
+    PerfEvents<N> perf_events_ {
+        "PERF_COUNT_SW_TASK_CLOCK"s,
+        "PERF_COUNT_HW_CPU_CYCLES"s,
+    };
+    array<uint64_t, N> begin_perf_results_;
+    array<uint64_t, N> stw_begin_perf_results_;
+    bool includePerf = false;
+    chrono::steady_clock::time_point begin_time_;
+    map<string, double> begin_vm_statistics_;
+
+    map<string, double> results_;
+    
+    // Workarround to returnt he results back to the caller,
+    // if the caller's logs don't show messages printed here.
+    char** keys_ptr;
+    double* values_ptr;
+    int ptr_size;
+    string result_as_string;
+
+    void SetResult(const string& key, double value) {
+        results_[key] = value;
+    }
+
+    void AddResult(const string& key, double value) {
+        results_[key] += value;
+    }
+
+    string ToString(double value) {
+        stringstream ss;
+        ss << fixed << setprecision(2) << value;
+        return ss.str();
+    }
+
+
+    void CalculateResults() {
+        if (results_.find("time") != results_.end() && results_.find("time.stw") != results_.end()) {
+            results_["time.other"] = results_["time"] - results_["time.stw"];
+        }
+        for (size_t i = 0; i < perf_events_.num_events; i++) {
+            if (results_.find(perf_events_.names[i]) != results_.end() && results_.find(perf_events_.names[i] + ".stw") != results_.end()) {
+                results_[perf_events_.names[i] + ".other"] = results_[perf_events_.names[i]] - results_[perf_events_.names[i] + ".stw"];
+            }
+        }
+
+        result_as_string = "============================ MMTk Statistics Totals ============================\n"; 
+        for (auto& x : results_) result_as_string +=  x.first + TAB;
+        result_as_string += "\n";
+        for (auto& x : results_) result_as_string +=  ToString(x.second) + TAB;
+        result_as_string += "\n";
+        result_as_string += "Total time: " + ToString(results_.find("time") == results_.end() ? 0 : results_["time"]) + " ms" +"\n";
+        result_as_string += "------------------------------ End MMTk Statistics -----------------------------\n" ;
+    }
+
+    void Print() {
+        cout << "============================ MMTk Statistics Totals ============================" << endl;
+        for (auto& x : results_) cout << x.first << TAB;
+        cout << endl;
+        for (auto& x : results_) cout << ToString(x.second) << TAB;
+        cout << endl;
+        cout << "Total time: " << ToString(results_.find("time") == results_.end() ? 0 : results_["time"]) << " ms" << endl;
+        cout << "------------------------------ End MMTk Statistics -----------------------------" << endl;
+    }
+};
+
+static Harness harness {};
+
+extern "C" {
+    void harness_prepare(bool includePerfCounters) {
+        harness.HarnessPrepare(includePerfCounters);
+    }
+
+    void harness_begin(int gcCount, double gcTime) {
+        map<string, double> values; 
+        values["GC"] = gcCount;
+        values["time.stw"] = gcTime;
+        harness.HarnessBegin(values);
+        
+    } 
+
+    void harness_end(int gcCount, double gcTime) {
+        map<string, double> values; 
+        values["GC"] = gcCount;
+        values["time.stw"] = gcTime;
+        harness.HarnessEnd(values);
+    }
+
+    void harness_stw_begin() {
+        harness.STWBegin();
+    }
+    
+    void harness_stw_end() {
+        harness.STWEnd();
+    }
+
+    char* harness_result_as_string() {
+        return harness.GetResultAsString();
+    }
+}

--- a/harness-android/perf_event.hpp
+++ b/harness-android/perf_event.hpp
@@ -1,0 +1,122 @@
+#include <cstdlib>
+#include <cerrno>
+#include <cstring>
+#include <err.h>
+#include <string>
+#include <array>
+#include <limits>
+#include "assert.hpp"
+#include <linux/perf_event.h>
+#include <sys/syscall.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+using namespace std;
+
+static int perf_event_open(perf_event_attr* attr, pid_t pid, int cpu, int group_fd,
+                           unsigned long flags) {
+  return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+}
+
+void init_event_attr(std::string perf_event_name, perf_event_attr* pe) {
+    if (perf_event_name == "PERF_COUNT_SW_TASK_CLOCK") {
+        pe->type = PERF_TYPE_SOFTWARE;
+        pe->config = PERF_COUNT_SW_TASK_CLOCK;
+    } else if (perf_event_name == "PERF_COUNT_HW_CPU_CYCLES") {
+        pe->type = PERF_TYPE_HARDWARE;
+        pe->config = PERF_COUNT_HW_CPU_CYCLES;
+    } else if (perf_event_name == "PERF_COUNT_HW_INSTRUCTIONS") {
+        pe->type = PERF_TYPE_HARDWARE;
+        pe->config = PERF_COUNT_HW_INSTRUCTIONS;
+    } else {
+        ASSERT(false, "Unknown performance counter name");
+    }
+    pe->size = PERF_ATTR_SIZE_VER1;
+    pe->exclude_user = 0;
+    pe->exclude_kernel = 0;
+    pe->exclude_hv = 0;
+    pe->read_format = PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
+    pe->disabled = 1;
+    pe->inherit = 1;
+}
+
+template <size_t N>
+class PerfEvents {
+public:
+    const std::vector<std::string> names;
+    const size_t num_events = N;
+
+    PerfEvents(std::initializer_list<std::string> names): names { names } {
+        pfm_prepare();
+        for (size_t i = 0; i < N; i++) {
+            pfm_create(i, this->names[i].c_str());
+        }
+    }
+
+    void Enable() {
+        pfm_enable();
+    }
+
+    void Disable() {
+        pfm_disable();
+    }
+
+    std::array<uint64_t, N> ReadAll() const {
+        std::array<uint64_t, N> results;
+        for (size_t i = 0; i < N; i++) {
+            results[i] = pfm_read(i);
+        }
+        return results;
+    }
+private:
+    std::array<int, N> perf_event_fds_;
+    std::array<struct perf_event_attr, N> perf_event_attrs_;
+    bool initialized_ = false;
+
+    void pfm_prepare() {
+        for(size_t i = 0; i < N; i++) {
+            perf_event_attrs_[i].size = sizeof(struct perf_event_attr);
+        }
+        initialized_ = true;
+    }
+
+    void pfm_create(size_t id, const char* event_name) {
+        struct perf_event_attr* pe = &perf_event_attrs_[id];
+        init_event_attr(event_name, pe);
+        perf_event_fds_[id] = perf_event_open(pe, 0 /* pid */, -1 /* cpu */, -1 /* group_fd */, 0 /* flags */);
+        ASSERT(perf_event_fds_[id] != -1, "error in perf_event_open for event %zu '%s'", id, event_name);
+    }
+
+    void pfm_enable() {
+        ASSERT(initialized_, "perf events is not initialized");
+        for(size_t i = 0; i < N; i++) {
+            ioctl(perf_event_fds_[i], PERF_EVENT_IOC_RESET, 0);
+            ioctl(perf_event_fds_[i], PERF_EVENT_IOC_ENABLE, 0);
+        }
+    }
+
+    void pfm_disable() {
+        ASSERT(initialized_, "perf events is not initialized");
+        for(size_t i = 0; i < N; i++) {
+            ioctl(perf_event_fds_[i], PERF_EVENT_IOC_DISABLE, 0);
+        }
+    }
+
+    inline uint64_t pfm_read(size_t id) const {  
+        uint64_t values[3];
+        memset(values, 0, sizeof(values));
+        ssize_t ret = read(perf_event_fds_[id], values, sizeof(values));
+        if (ret < (ssize_t) sizeof(values)) {
+            cout << "pfm_read error: Read failed for perf counter " << names[id] << endl;
+            return 0;
+        } else {
+            if (values[1] != values[2]) {
+                cout << "pfm_read warning: Multiplexed counters for " << names[id] << "\n  "
+                    << "Counter total time enabled " << values[1] << "\n  "
+                    << "Counter total time running " << values[2] << endl;
+                return 0;
+            }
+            return values[0];
+        }
+        return 0;
+    }
+};


### PR DESCRIPTION
* Removed dependency on the 'pfm' library, and replaced it with native system calls to open the perf counters. Also removed the 'PerfEventData' struct which used to hold the perf counter values, and instead returned the value as a primitive integer.

* Print statements from the harness were not showing in Android logcat. As a workaround, I provided a function to return the results as a string to the caller to print them.